### PR TITLE
Resolve requests for federation entities in parallel

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -103,6 +103,7 @@ func (b *builder) bindField(obj *Object, f *Field) (errret error) {
 		f.GoReceiverName = "ec"
 		f.GoFieldName = "__resolve_entities"
 		f.MethodHasContext = true
+		f.NoErr = true
 		return nil
 	case f.Name == "_service":
 		f.GoFieldType = GoFieldMethod

--- a/example/federation/accounts/graph/generated/federation.go
+++ b/example/federation/accounts/graph/generated/federation.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/99designs/gqlgen/plugin/federation/fedruntime"
 )
@@ -30,32 +31,67 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 	}, nil
 }
 
-func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
-	list := []fedruntime.Entity{}
-	for _, rep := range representations {
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) []fedruntime.Entity {
+	list := make([]fedruntime.Entity, len(representations))
+	resolveEntity := func(ctx context.Context, i int, rep map[string]interface{}) (err error) {
+		// we need to do our own panic handling, because we may be called in a
+		// goroutine, where the usual panic handling can't catch us
+		defer func() {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+			}
+		}()
+
 		typeName, ok := rep["__typename"].(string)
 		if !ok {
-			return nil, errors.New("__typename must be an existing string")
+			return errors.New("__typename must be an existing string")
 		}
 		switch typeName {
 
 		case "User":
 			id0, err := ec.unmarshalNID2string(ctx, rep["id"])
 			if err != nil {
-				return nil, errors.New(fmt.Sprintf("Field %s undefined in schema.", "id"))
+				return errors.New(fmt.Sprintf("Field %s undefined in schema.", "id"))
 			}
 
 			entity, err := ec.resolvers.Entity().FindUserByID(ctx,
 				id0)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			list = append(list, entity)
+			list[i] = entity
+			return nil
 
 		default:
-			return nil, errors.New("unknown type: " + typeName)
+			return errors.New("unknown type: " + typeName)
 		}
 	}
-	return list, nil
+
+	// if there are multiple entities to resolve, parallelize (similar to
+	// graphql.FieldSet.Dispatch)
+	switch len(representations) {
+	case 0:
+		return list
+	case 1:
+		err := resolveEntity(ctx, 0, representations[0])
+		if err != nil {
+			ec.Error(ctx, err)
+		}
+		return list
+	default:
+		var g sync.WaitGroup
+		g.Add(len(representations))
+		for i, rep := range representations {
+			go func(i int, rep map[string]interface{}) {
+				err := resolveEntity(ctx, i, rep)
+				if err != nil {
+					ec.Error(ctx, err)
+				}
+				g.Done()
+			}(i, rep)
+		}
+		g.Wait()
+		return list
+	}
 }

--- a/example/federation/accounts/graph/generated/generated.go
+++ b/example/federation/accounts/graph/generated/generated.go
@@ -415,7 +415,7 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.__resolve_entities(ctx, args["representations"].([]map[string]interface{}))
+		return ec.__resolve_entities(ctx, args["representations"].([]map[string]interface{})), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/example/federation/products/graph/generated/generated.go
+++ b/example/federation/products/graph/generated/generated.go
@@ -552,7 +552,7 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.__resolve_entities(ctx, args["representations"].([]map[string]interface{}))
+		return ec.__resolve_entities(ctx, args["representations"].([]map[string]interface{})), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/example/federation/reviews/graph/generated/federation.go
+++ b/example/federation/reviews/graph/generated/federation.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/99designs/gqlgen/plugin/federation/fedruntime"
 )
@@ -30,46 +31,82 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 	}, nil
 }
 
-func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
-	list := []fedruntime.Entity{}
-	for _, rep := range representations {
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) []fedruntime.Entity {
+	list := make([]fedruntime.Entity, len(representations))
+	resolveEntity := func(ctx context.Context, i int, rep map[string]interface{}) (err error) {
+		// we need to do our own panic handling, because we may be called in a
+		// goroutine, where the usual panic handling can't catch us
+		defer func() {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+			}
+		}()
+
 		typeName, ok := rep["__typename"].(string)
 		if !ok {
-			return nil, errors.New("__typename must be an existing string")
+			return errors.New("__typename must be an existing string")
 		}
 		switch typeName {
 
 		case "Product":
 			id0, err := ec.unmarshalNString2string(ctx, rep["upc"])
 			if err != nil {
-				return nil, errors.New(fmt.Sprintf("Field %s undefined in schema.", "upc"))
+				return errors.New(fmt.Sprintf("Field %s undefined in schema.", "upc"))
 			}
 
 			entity, err := ec.resolvers.Entity().FindProductByUpc(ctx,
 				id0)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			list = append(list, entity)
+			list[i] = entity
+			return nil
 
 		case "User":
 			id0, err := ec.unmarshalNID2string(ctx, rep["id"])
 			if err != nil {
-				return nil, errors.New(fmt.Sprintf("Field %s undefined in schema.", "id"))
+				return errors.New(fmt.Sprintf("Field %s undefined in schema.", "id"))
 			}
 
 			entity, err := ec.resolvers.Entity().FindUserByID(ctx,
 				id0)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			list = append(list, entity)
+			list[i] = entity
+			return nil
 
 		default:
-			return nil, errors.New("unknown type: " + typeName)
+			return errors.New("unknown type: " + typeName)
 		}
 	}
-	return list, nil
+
+	// if there are multiple entities to resolve, parallelize (similar to
+	// graphql.FieldSet.Dispatch)
+	switch len(representations) {
+	case 0:
+		return list
+	case 1:
+		err := resolveEntity(ctx, 0, representations[0])
+		if err != nil {
+			ec.Error(ctx, err)
+		}
+		return list
+	default:
+		var g sync.WaitGroup
+		g.Add(len(representations))
+		for i, rep := range representations {
+			go func(i int, rep map[string]interface{}) {
+				err := resolveEntity(ctx, i, rep)
+				if err != nil {
+					ec.Error(ctx, err)
+				}
+				g.Done()
+			}(i, rep)
+		}
+		g.Wait()
+		return list
+	}
 }

--- a/example/federation/reviews/graph/generated/generated.go
+++ b/example/federation/reviews/graph/generated/generated.go
@@ -568,7 +568,7 @@ func (ec *executionContext) _Query__entities(ctx context.Context, field graphql.
 	fc.Args = args
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.__resolve_entities(ctx, args["representations"].([]map[string]interface{}))
+		return ec.__resolve_entities(ctx, args["representations"].([]map[string]interface{})), nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/plugin/federation/federation.gotpl
+++ b/plugin/federation/federation.gotpl
@@ -2,6 +2,7 @@
 {{ reserveImport "errors"  }}
 {{ reserveImport "fmt"  }}
 {{ reserveImport "strings"  }}
+{{ reserveImport "sync"  }}
 
 {{ reserveImport "github.com/99designs/gqlgen/plugin/federation/fedruntime" }}
 
@@ -25,12 +26,20 @@ func (ec *executionContext) __resolve__service(ctx context.Context) (fedruntime.
 }
 
 {{if .Entities}}
-func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) ([]fedruntime.Entity, error) {
-	list := []fedruntime.Entity{}
-	for _, rep := range representations {
+func (ec *executionContext) __resolve_entities(ctx context.Context, representations []map[string]interface{}) []fedruntime.Entity {
+	list := make([]fedruntime.Entity, len(representations))
+	resolveEntity := func(ctx context.Context, i int, rep map[string]interface{}) (err error) {
+		// we need to do our own panic handling, because we may be called in a
+		// goroutine, where the usual panic handling can't catch us
+		defer func () {
+			if r := recover(); r != nil {
+				err = ec.Recover(ctx, r)
+			}
+		}()
+
 		typeName, ok := rep["__typename"].(string)
 		if !ok {
-			return nil, errors.New("__typename must be an existing string")
+			return errors.New("__typename must be an existing string")
 		}
 		switch typeName {
 		{{ range .Entities }}
@@ -39,31 +48,58 @@ func (ec *executionContext) __resolve_entities(ctx context.Context, representati
 				{{ range $i, $keyField := .KeyFields -}}
 					id{{$i}}, err := ec.{{.TypeReference.UnmarshalFunc}}(ctx, rep["{{$keyField.Field.Name}}"])
 					if err != nil {
-						return nil, errors.New(fmt.Sprintf("Field %s undefined in schema.", "{{$keyField.Field.Name}}"))
+						return errors.New(fmt.Sprintf("Field %s undefined in schema.", "{{$keyField.Field.Name}}"))
 					}
 				{{end}}
 	
 				entity, err := ec.resolvers.Entity().{{.ResolverName | go}}(ctx,
 					{{ range $i, $_ := .KeyFields -}} id{{$i}}, {{end}})
 				if err != nil {
-					return nil, err
+					return err
 				}
 	
 				{{ range .Requires }}
 					{{ range .Fields}}
 						entity.{{.NameGo}}, err = ec.{{.TypeReference.UnmarshalFunc}}(ctx, rep["{{.Name}}"])
 						if err != nil {
-							return nil, err
+							return err
 						}
 					{{ end }}
 				{{ end }}
-				list = append(list, entity)
+				list[i] = entity
+				return nil
 			{{ end }}
 		{{ end }}
 		default:
-			return nil, errors.New("unknown type: "+typeName)
+			return errors.New("unknown type: "+typeName)
 		}
 	}
-	return list, nil
+
+	// if there are multiple entities to resolve, parallelize (similar to
+	// graphql.FieldSet.Dispatch)
+	switch len(representations) {
+	case 0:
+		return list
+	case 1:
+		err := resolveEntity(ctx, 0, representations[0])
+		if err != nil {
+			ec.Error(ctx, err)
+		}
+		return list
+	default:
+		var g sync.WaitGroup
+		g.Add(len(representations))
+		for i, rep := range representations {
+			go func(i int, rep map[string]interface{}) {
+				err := resolveEntity(ctx, i, rep)
+				if err != nil {
+					ec.Error(ctx, err)
+				}
+				g.Done()
+			}(i, rep)
+		}
+		g.Wait()
+		return list
+	}
 }
 {{end}}


### PR DESCRIPTION
In apollo federation, we may be asked for data about a list of entities.
These can typically be resolved in parallel, just as with sibling fields
in ordinary GraphQL queries.  Now we do!

I also changed the behavior such that if one lookup fails, we don't
cancel the others.  This is more consistent with the behavior of other
resolvers, and is more natural now that they execute in parallel.  This,
plus panic handling, required a little refactoring.

The examples probably give the clearest picture of the changes. (And the
clearest test; the changed functionality is already exercised by
`integration-test.js` as watching the test server logs will attest.)

Fixes #1278.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
